### PR TITLE
Add touch-and-tilt physics sandbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>My Mobile Web Game</title>
+<title>Physics Sandbox</title>
 <style>
   html, body { margin:0; height:100%; background:#0b0b0b; touch-action:none; }
   canvas { display:block; width:100vw; height:100vh; }
@@ -12,44 +12,103 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d', { alpha:false });
 
+let width = 0, height = 0;
 function resize() {
   const ratio = window.devicePixelRatio || 1;
   canvas.width = Math.floor(window.innerWidth * ratio);
   canvas.height = Math.floor(window.innerHeight * ratio);
   ctx.setTransform(ratio,0,0,ratio,0,0);
+  width = canvas.width / ratio;
+  height = canvas.height / ratio;
 }
 addEventListener('resize', resize, { passive:true });
 resize();
 
-// Simple input state for touch
-const input = { touches:[] };
-canvas.addEventListener('pointerdown', e => { canvas.setPointerCapture(e.pointerId); input.touches=[{x:e.clientX,y:e.clientY}]; });
-canvas.addEventListener('pointermove', e => { if (e.pressure>0) input.touches=[{x:e.clientX,y:e.clientY}]; });
-canvas.addEventListener('pointerup',   () => { input.touches=[]; });
+// Gravity from device tilt (defaults to downwards)
+const gravity = { x:0, y:500 };
+window.addEventListener('deviceorientation', e => {
+  const g = 500;
+  if (e.gamma !== null && e.beta !== null) {
+    gravity.x = g * (e.gamma / 90);
+    gravity.y = g * (e.beta / 90);
+  }
+}, true);
 
-// Demo state
-let t = 0;
-function update(dt) { t += dt; }
+// Balls in the sandbox
+const balls = [];
+canvas.addEventListener('pointerdown', e => {
+  const rect = canvas.getBoundingClientRect();
+  balls.push({
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top,
+    vx: 0,
+    vy: 0,
+    r: 20
+  });
+});
+
+function collideEdges(b) {
+  if (b.x - b.r < 0) { b.x = b.r; b.vx = Math.abs(b.vx) * 0.7; }
+  if (b.x + b.r > width) { b.x = width - b.r; b.vx = -Math.abs(b.vx) * 0.7; }
+  if (b.y - b.r < 0) { b.y = b.r; b.vy = Math.abs(b.vy) * 0.7; }
+  if (b.y + b.r > height) { b.y = height - b.r; b.vy = -Math.abs(b.vy) * 0.7; }
+}
+
+function collideBalls() {
+  for (let i = 0; i < balls.length; i++) {
+    for (let j = i + 1; j < balls.length; j++) {
+      const a = balls[i], b = balls[j];
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.hypot(dx, dy);
+      const min = a.r + b.r;
+      if (dist > 0 && dist < min) {
+        const nx = dx / dist;
+        const ny = dy / dist;
+        const overlap = min - dist;
+        a.x -= nx * overlap / 2;
+        a.y -= ny * overlap / 2;
+        b.x += nx * overlap / 2;
+        b.y += ny * overlap / 2;
+        const p = (a.vx * nx + a.vy * ny - b.vx * nx - b.vy * ny);
+        a.vx -= p * nx;
+        a.vy -= p * ny;
+        b.vx += p * nx;
+        b.vy += p * ny;
+      }
+    }
+  }
+}
+
+function update(dt) {
+  for (const b of balls) {
+    b.vx += gravity.x * dt;
+    b.vy += gravity.y * dt;
+    b.x += b.vx * dt;
+    b.y += b.vy * dt;
+    collideEdges(b);
+  }
+  collideBalls();
+}
+
 function draw() {
   ctx.fillStyle = '#101014';
-  ctx.fillRect(0,0,canvas.width,canvas.height);
-  // Visualize touches
-  for (const p of input.touches) {
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = '#39f';
+  for (const b of balls) {
     ctx.beginPath();
-    ctx.arc(p.x, p.y, 40, 0, Math.PI*2);
-    ctx.fillStyle = '#39f';
+    ctx.arc(b.x, b.y, b.r, 0, Math.PI * 2);
     ctx.fill();
   }
-  // Simple animated text
   ctx.fillStyle = '#fff';
   ctx.font = '20px system-ui, sans-serif';
-  ctx.fillText('Touch and drag', 20, 40 + Math.sin(t*2)*4);
+  ctx.fillText('Tap to add balls. Tilt to move them.', 20, 40);
 }
 
 // Game loop
 let last = performance.now();
 function loop(now) {
-  const dt = Math.min(0.033, (now - last)/1000);
+  const dt = Math.min(0.033, (now - last) / 1000);
   last = now;
   update(dt);
   draw();


### PR DESCRIPTION
## Summary
- Add canvas-based physics sandbox that lets players drop balls with touch
- Use device tilt to influence gravity and motion
- Implement basic collision detection between balls and edges

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c3859dc832b9896d962fd683ee8