### PR TITLE
Expand physics sandbox with material selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,54 +2,234 @@
 <html lang="en">
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>My Mobile Web Game</title>
+<title>Physics Sandbox</title>
 <style>
   html, body { margin:0; height:100%; background:#0b0b0b; touch-action:none; }
   canvas { display:block; width:100vw; height:100vh; }
+  #ui { position:fixed; top:10px; left:10px; color:#fff; font:16px system-ui,sans-serif; z-index:10; }
+  #ui label { margin-right:10px; }
 </style>
+<div id="ui">
+  <label>Mode:
+    <select id="mode">
+      <option value="place">Place</option>
+      <option value="interact">Interact</option>
+    </select>
+  </label>
+  <label>Object:
+    <select id="object">
+      <option value="ball">Ball</option>
+      <option value="sand">Sand</option>
+      <option value="water">Water</option>
+      <option value="ice">Ice Cube</option>
+      <option value="seed">Palm Seed</option>
+      <option value="dynamite">Dynamite</option>
+    </select>
+  </label>
+</div>
 <canvas id="game"></canvas>
 <script>
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d', { alpha:false });
 
+let width = 0, height = 0;
 function resize() {
   const ratio = window.devicePixelRatio || 1;
   canvas.width = Math.floor(window.innerWidth * ratio);
   canvas.height = Math.floor(window.innerHeight * ratio);
   ctx.setTransform(ratio,0,0,ratio,0,0);
+  width = canvas.width / ratio;
+  height = canvas.height / ratio;
 }
 addEventListener('resize', resize, { passive:true });
 resize();
 
-// Simple input state for touch
-const input = { touches:[] };
-canvas.addEventListener('pointerdown', e => { canvas.setPointerCapture(e.pointerId); input.touches=[{x:e.clientX,y:e.clientY}]; });
-canvas.addEventListener('pointermove', e => { if (e.pressure>0) input.touches=[{x:e.clientX,y:e.clientY}]; });
-canvas.addEventListener('pointerup',   () => { input.touches=[]; });
+// Gravity always downwards
+const gravity = { x:0, y:500 };
 
-// Demo state
-let t = 0;
-function update(dt) { t += dt; }
+// Sandbox objects
+const objects = [];
+
+function createObject(type, x, y) {
+  switch(type) {
+    case 'sand': return {type, x, y, vx:0, vy:0, r:4, bounce:0.2, color:'#dba'};
+    case 'water': return {type, x, y, vx:0, vy:0, r:4, bounce:0, color:'#39f'};
+    case 'ice': return {type, x, y, vx:0, vy:0, r:15, startR:15, bounce:0.3, color:'#9cf', melt:30};
+    case 'seed': return {type, x, y, vx:0, vy:0, r:5, bounce:0.2, color:'#964B00', grow:180};
+    case 'dynamite': return {type, x, y, vx:0, vy:0, r:8, bounce:0.3, color:'#f00', timer:5};
+    case 'ball': default: return {type:'ball', x, y, vx:0, vy:0, r:20, bounce:0.7, color:'#f88'};
+  }
+}
+
+let dragObj = null;
+let dragOffsetX = 0, dragOffsetY = 0;
+
+canvas.addEventListener('pointerdown', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const mode = document.getElementById('mode').value;
+  if (mode === 'place') {
+    const type = document.getElementById('object').value;
+    objects.push(createObject(type, x, y));
+  } else {
+    for (let i = objects.length-1; i>=0; i--) {
+      const o = objects[i];
+      if (o.type === 'tree') continue;
+      const dx = x - o.x;
+      const dy = y - o.y;
+      if (Math.hypot(dx,dy) <= o.r) {
+        dragObj = o;
+        dragOffsetX = dx;
+        dragOffsetY = dy;
+        break;
+      }
+    }
+  }
+});
+
+canvas.addEventListener('pointermove', e => {
+  if (!dragObj) return;
+  const rect = canvas.getBoundingClientRect();
+  dragObj.x = e.clientX - rect.left - dragOffsetX;
+  dragObj.y = e.clientY - rect.top - dragOffsetY;
+  dragObj.vx = 0;
+  dragObj.vy = 0;
+});
+
+canvas.addEventListener('pointerup', () => { dragObj = null; });
+
+function collideEdges(o) {
+  if (o.x - o.r < 0) { o.x = o.r; o.vx = Math.abs(o.vx) * o.bounce; }
+  if (o.x + o.r > width) { o.x = width - o.r; o.vx = -Math.abs(o.vx) * o.bounce; }
+  if (o.y - o.r < 0) { o.y = o.r; o.vy = Math.abs(o.vy) * o.bounce; }
+  if (o.y + o.r > height) { o.y = height - o.r; o.vy = -Math.abs(o.vy) * o.bounce; }
+}
+
+function collideObjects() {
+  for (let i = 0; i < objects.length; i++) {
+    const a = objects[i];
+    if (a.type === 'tree') continue;
+    for (let j = i + 1; j < objects.length; j++) {
+      const b = objects[j];
+      if (b.type === 'tree') continue;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.hypot(dx, dy);
+      const min = a.r + b.r;
+      if (dist > 0 && dist < min) {
+        const nx = dx / dist;
+        const ny = dy / dist;
+        const overlap = min - dist;
+        a.x -= nx * overlap / 2;
+        a.y -= ny * overlap / 2;
+        b.x += nx * overlap / 2;
+        b.y += ny * overlap / 2;
+        const p = (a.vx * nx + a.vy * ny - b.vx * nx - b.vy * ny);
+        const bounce = Math.min(a.bounce, b.bounce);
+        a.vx -= p * nx * bounce;
+        a.vy -= p * ny * bounce;
+        b.vx += p * nx * bounce;
+        b.vy += p * ny * bounce;
+      }
+    }
+  }
+}
+
+function update(dt) {
+  for (let i = objects.length-1; i>=0; i--) {
+    const o = objects[i];
+    if (o.type === 'tree') continue;
+    o.vx += gravity.x * dt;
+    o.vy += gravity.y * dt;
+    o.x += o.vx * dt;
+    o.y += o.vy * dt;
+    collideEdges(o);
+
+    if (o.type === 'ice') {
+      o.melt -= dt;
+      o.r = o.startR * (o.melt / 30);
+      if (o.melt <= 0) {
+        objects.splice(i,1);
+        objects.push(createObject('water', o.x, o.y));
+        continue;
+      }
+    }
+
+    if (o.type === 'seed') {
+      if (Math.abs(o.vx) < 5 && Math.abs(o.vy) < 5 && o.y + o.r >= height-1) {
+        o.grow -= dt;
+      } else {
+        o.grow = 180;
+      }
+      if (o.grow <= 0) {
+        objects.splice(i,1);
+        objects.push({type:'tree', x:o.x, y:height, size:0});
+        continue;
+      }
+    }
+
+    if (o.type === 'dynamite') {
+      o.timer -= dt;
+      if (o.timer <= 0) {
+        objects.splice(i,1);
+        for (const other of objects) {
+          if (other === o) continue;
+          const dx = other.x - o.x;
+          const dy = other.y - o.y;
+          const dist = Math.hypot(dx,dy);
+          if (dist < 100 && dist > 0) {
+            const force = 1000 / dist;
+            other.vx += (dx / dist) * force;
+            other.vy += (dy / dist) * force;
+          }
+        }
+        continue;
+      }
+    }
+
+    if (o.type === 'ball') {
+      for (const w of objects) {
+        if (w.type !== 'water') continue;
+        const dx = w.x - o.x;
+        const dy = w.y - o.y;
+        const dist = Math.hypot(dx,dy);
+        const min = w.r + o.r;
+        if (dist < min && dy > 0) {
+          const overlap = min - dist;
+          o.y -= overlap;
+          o.vy -= 50 * overlap;
+        }
+      }
+    }
+  }
+  collideObjects();
+}
+
 function draw() {
   ctx.fillStyle = '#101014';
-  ctx.fillRect(0,0,canvas.width,canvas.height);
-  // Visualize touches
-  for (const p of input.touches) {
+  ctx.fillRect(0, 0, width, height);
+  for (const o of objects) {
+    if (o.type === 'tree') {
+      ctx.fillStyle = '#964B00';
+      ctx.fillRect(o.x-5, height-60, 10, 60);
+      ctx.fillStyle = '#0a5';
+      ctx.beginPath();
+      ctx.arc(o.x, height-60, 30, 0, Math.PI, true);
+      ctx.fill();
+      continue;
+    }
+    ctx.fillStyle = o.color || '#fff';
     ctx.beginPath();
-    ctx.arc(p.x, p.y, 40, 0, Math.PI*2);
-    ctx.fillStyle = '#39f';
+    ctx.arc(o.x, o.y, o.r, 0, Math.PI*2);
     ctx.fill();
   }
-  // Simple animated text
-  ctx.fillStyle = '#fff';
-  ctx.font = '20px system-ui, sans-serif';
-  ctx.fillText('Touch and drag', 20, 40 + Math.sin(t*2)*4);
 }
 
 // Game loop
 let last = performance.now();
 function loop(now) {
-  const dt = Math.min(0.033, (now - last)/1000);
+  const dt = Math.min(0.033, (now - last) / 1000);
   last = now;
   update(dt);
   draw();


### PR DESCRIPTION
## Summary
- Remove tilt-based gravity and keep constant downward pull
- Add place/interact modes with UI to drag or drop items
- Introduce multiple object types with unique behaviors like melting ice, growing seeds, and exploding dynamite

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c3859dc832b9896d962fd683ee8