### PR TITLE
Add serene soil landscape with day-night sky

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,327 +1,271 @@
 <!doctype html>
 <html lang="en">
+<head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>Physics Sandbox</title>
+<title>Serene Soil</title>
 <style>
-  html, body { margin:0; height:100%; background:#0b0b0b; touch-action:none; }
-  #toolbar { position:fixed; top:0; left:0; right:0; background:#222; color:#fff; font-family:sans-serif; padding:4px; display:flex; gap:8px; z-index:10; }
-  #toolbar button { background:#444; border:0; color:#fff; padding:4px 8px; cursor:pointer; }
-  #toolbar button.selected { background:#888; }
-  #toolbar label { margin-left:8px; }
-  canvas { position:absolute; left:0; }
+  html, body { margin:0; height:100%; background:#000; touch-action:none; }
+  canvas { position:absolute; left:0; top:0; image-rendering:pixelated; }
 </style>
-<div id="toolbar">
-  <div class="materials">
-    <button data-mat="2" class="selected">Water</button>
-    <button data-mat="1">Sand</button>
-    <button data-mat="3">Soil</button>
-    <button data-mat="5">Bomb</button>
-  </div>
-  <div class="modes">
-    <label><input type="radio" name="mode" value="place" checked>Place</label>
-    <label><input type="radio" name="mode" value="interact">Interact</label>
-  </div>
-</div>
+</head>
+<body>
 <canvas id="game"></canvas>
 <script>
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d', { alpha:false });
-const toolbar = document.getElementById('toolbar');
 
-// Material constants
-const EMPTY=0, SAND=1, WATER=2, SOIL=3, GRASS=4, BOMB=5;
-const cellSize = 4;  // grid cell size in pixels
+// material constants
+const EMPTY=0, SOIL=1, GRASS=2;
+const cellSize = 4;
 
 let width=0, height=0;
 let simCols=0, simRows=0;
 let grid=[], isStatic=[];
-let bombs=[];
-let soilExposeTime={}, grassCoverTime={};
-let currentMaterial = WATER;
-let currentMode = 'place';
+let soilExposeTime={};
 
-function resize() {
-  const ratio = window.devicePixelRatio || 1;
-  const uiHeight = toolbar.offsetHeight;
-  width = window.innerWidth;
-  height = window.innerHeight - uiHeight;
-  canvas.style.top = uiHeight + 'px';
-  canvas.style.width = width + 'px';
-  canvas.style.height = height + 'px';
-  canvas.width = width * ratio;
-  canvas.height = height * ratio;
-  ctx.setTransform(ratio,0,0,ratio,0,0);
-  simCols = Math.floor(width / cellSize);
-  simRows = Math.floor(height / cellSize);
-  grid = Array.from({length: simRows}, () => Array(simCols).fill(EMPTY));
-  isStatic = Array.from({length: simRows}, () => Array(simCols).fill(false));
+let frame=0;
+// begin during daylight so the initial scene isn't black
+let dayTime=75;
+let stars=[], clouds=[];
+
+function lerp(a,b,t){ return a+(b-a)*t; }
+function mixColor(c1,c2,t){
+  const r1=parseInt(c1.slice(1,3),16), g1=parseInt(c1.slice(3,5),16), b1=parseInt(c1.slice(5,7),16);
+  const r2=parseInt(c2.slice(1,3),16), g2=parseInt(c2.slice(3,5),16), b2=parseInt(c2.slice(5,7),16);
+  const r=Math.round(lerp(r1,r2,t)), g=Math.round(lerp(g1,g2,t)), b=Math.round(lerp(b1,b2,t));
+  return `rgb(${r},${g},${b})`;
 }
-addEventListener('resize', resize, { passive:true });
+
+function initSky(){
+  stars = Array.from({length:100}, () => ({
+    x: Math.random()*width,
+    y: Math.random()*height*0.5,
+    size: Math.random()*2+1,
+    alpha: Math.random()*0.5+0.5
+  }));
+  clouds = Array.from({length:5}, () => ({
+    x: Math.random()*width,
+    y: Math.random()*height*0.3,
+    speed: 10+Math.random()*20
+  }));
+}
+
+function createTerrain(){
+  const base = Math.floor(simRows*0.75);
+  let h = base;
+  for (let x=0; x<simCols; x++){
+    h += Math.floor(Math.random()*3)-1;
+    h = Math.max(Math.floor(simRows*0.5), Math.min(simRows-1, h));
+    for (let y=h; y<simRows; y++){
+      grid[y][x] = SOIL;
+      isStatic[y][x] = true;
+    }
+    grid[h][x] = GRASS;
+  }
+}
+
+function resize(){
+  const ratio = window.devicePixelRatio || 1;
+  width = window.innerWidth;
+  height = window.innerHeight;
+  canvas.style.width = width+'px';
+  canvas.style.height = height+'px';
+  canvas.width = width*ratio;
+  canvas.height = height*ratio;
+  ctx.setTransform(ratio,0,0,ratio,0,0);
+  simCols = Math.floor(width/cellSize);
+  simRows = Math.floor(height/cellSize);
+  grid = Array.from({length:simRows}, () => Array(simCols).fill(EMPTY));
+  isStatic = Array.from({length:simRows}, () => Array(simCols).fill(false));
+  soilExposeTime = {};
+  initSky();
+  createTerrain();
+}
+addEventListener('resize', resize, {passive:true});
 resize();
 
-let frame = 0;
-function updateParticles() {
+function updateParticles(){
   frame++;
-  const biasLeftFirst = (frame % 2 === 0);
-  for (let y = simRows - 2; y >= 0; y--) {
-    const xStart = (frame % 2 === 0 ? 0 : simCols - 1);
-    const xEnd   = (frame % 2 === 0 ? simCols : -1);
-    const xStep  = (frame % 2 === 0 ? 1 : -1);
-    for (let x = xStart; x !== xEnd; x += xStep) {
-      const type = grid[y][x];
-      if (type===EMPTY || type===GRASS) continue;
-      if (isStatic[y][x]) continue;
-      const belowY = y + 1;
-      const leftX = x - 1, rightX = x + 1;
-      const inBoundsX = nx => (nx >= 0 && nx < simCols);
-      const cell = (r,c) => grid[r]?.[c];
-      let moved = false;
-      if (cell(belowY, x) === EMPTY) {
-        grid[belowY][x] = type;
+  for (let y=simRows-2; y>=0; y--){
+    const xStart = frame%2===0 ? 0 : simCols-1;
+    const xEnd = frame%2===0 ? simCols : -1;
+    const xStep = frame%2===0 ? 1 : -1;
+    for (let x=xStart; x!==xEnd; x+=xStep){
+      if (grid[y][x] !== SOIL || isStatic[y][x]) continue;
+      const belowY = y+1;
+      if (grid[belowY][x] === EMPTY){
+        grid[belowY][x] = SOIL;
         grid[y][x] = EMPTY;
         isStatic[belowY][x] = false;
         isStatic[y][x] = false;
-        if (y - 1 >= 0 && isStatic[y-1][x]) isStatic[y-1][x] = false;
-        moved = true;
-      } else if (biasLeftFirst) {
-        if (inBoundsX(leftX) && cell(belowY, leftX) === EMPTY) {
-          grid[belowY][leftX] = type;
-          grid[y][x] = EMPTY;
-          isStatic[belowY][leftX] = false;
-          isStatic[y][x] = false;
-          if (y - 1 >= 0 && isStatic[y-1][x]) isStatic[y-1][x] = false;
-          moved = true;
-        } else if (inBoundsX(rightX) && cell(belowY, rightX) === EMPTY) {
-          grid[belowY][rightX] = type;
-          grid[y][x] = EMPTY;
-          isStatic[belowY][rightX] = false;
-          isStatic[y][x] = false;
-          if (y - 1 >= 0 && isStatic[y-1][x]) isStatic[y-1][x] = false;
-          moved = true;
-        }
+        if (y>0) isStatic[y-1][x] = false;
       } else {
-        if (inBoundsX(rightX) && cell(belowY, rightX) === EMPTY) {
-          grid[belowY][rightX] = type;
-          grid[y][x] = EMPTY;
-          isStatic[belowY][rightX] = false;
-          isStatic[y][x] = false;
-          if (y - 1 >= 0 && isStatic[y-1][x]) isStatic[y-1][x] = false;
-          moved = true;
-        } else if (inBoundsX(leftX) && cell(belowY, leftX) === EMPTY) {
-          grid[belowY][leftX] = type;
-          grid[y][x] = EMPTY;
-          isStatic[belowY][leftX] = false;
-          isStatic[y][x] = false;
-          if (y - 1 >= 0 && isStatic[y-1][x]) isStatic[y-1][x] = false;
-          moved = true;
-        }
-      }
-      if (!moved && type === WATER) {
-        if (cell(belowY, x) !== EMPTY) {
-          const dir = Math.random() < 0.5 ? -1 : 1;
-          for (let attempt = 0; attempt < 2; attempt++) {
-            const nx = (attempt === 0 ? x + dir : x - dir);
-            if (inBoundsX(nx) && cell(y, nx) === EMPTY && cell(belowY, nx) !== EMPTY) {
-              grid[y][nx] = WATER;
-              grid[y][x] = EMPTY;
-              isStatic[y][nx] = false;
-              isStatic[y][x] = false;
-              moved = true;
-              break;
-            }
+        const dirs = frame%2===0 ? [-1,1] : [1,-1];
+        let moved = false;
+        for (const dx of dirs){
+          const nx = x+dx;
+          if (nx>=0 && nx<simCols && grid[belowY][nx] === EMPTY){
+            grid[belowY][nx] = SOIL;
+            grid[y][x] = EMPTY;
+            isStatic[belowY][nx] = false;
+            isStatic[y][x] = false;
+            if (y>0) isStatic[y-1][x] = false;
+            moved = true;
+            break;
           }
         }
-      }
-      if (!moved && cell(belowY, x) !== undefined) {
-        const belowType = cell(belowY, x);
-        const density = { [WATER]:1, [SAND]:2, [SOIL]:2, [BOMB]:3 };
-        if (belowType !== EMPTY && density[type] > density[belowType]) {
-          grid[belowY][x] = type;
-          grid[y][x] = belowType;
-          isStatic[belowY][x] = false;
-          isStatic[y][x] = false;
-          moved = true;
-        }
-      }
-      if (!moved) {
-        isStatic[y][x] = true;
+        if (!moved) isStatic[y][x] = true;
       }
     }
   }
 }
 
-const BLAST_RADIUS = 5;
-const BLAST_INNER = 2;
-function updateBombs(dt) {
-  for (let i = bombs.length - 1; i >= 0; i--) {
-    bombs[i].fuse -= dt;
-    if (bombs[i].fuse <= 0) {
-      const bx = bombs[i].x, by = bombs[i].y;
-      grid[by][bx] = EMPTY;
-      isStatic[by][bx] = false;
-      for (let yy = Math.max(0, by - BLAST_RADIUS); yy <= Math.min(simRows-1, by + BLAST_RADIUS); yy++) {
-        for (let xx = Math.max(0, bx - BLAST_RADIUS); xx <= Math.min(simCols-1, bx + BLAST_RADIUS); xx++) {
-          const dx = xx - bx, dy = yy - by;
-          const distSq = dx*dx + dy*dy;
-          if (distSq <= BLAST_RADIUS * BLAST_RADIUS) {
-            const dist = Math.sqrt(distSq);
-            if (dist <= BLAST_INNER) {
-              if (grid[yy][xx] !== EMPTY) {
-                grid[yy][xx] = EMPTY;
-                isStatic[yy][xx] = false;
-                delete soilExposeTime[`${xx},${yy}`];
-                delete grassCoverTime[`${xx},${yy}`];
-              }
-            } else {
-              if (grid[yy][xx] !== EMPTY && grid[yy][xx] !== BOMB) {
-                const pushX = dx / dist, pushY = dy / dist;
-                const force = 1 / distSq;
-                const throwDist = Math.min(Math.ceil(force * BLAST_RADIUS * 2), BLAST_RADIUS);
-                let newX = xx + Math.round(pushX * throwDist);
-                let newY = yy + Math.round(pushY * throwDist);
-                newX = Math.max(0, Math.min(simCols-1, newX));
-                newY = Math.max(0, Math.min(simRows-1, newY));
-                if (!(newX === xx && newY === yy)) {
-                  if (grid[newY][newX] !== EMPTY) {
-                    let placed = false;
-                    for (let oy = -1; oy <= 1 && !placed; oy++) {
-                      for (let ox = -1; ox <= 1 && !placed; ox++) {
-                        const tx = xx + ox, ty = yy + oy;
-                        if (tx>=0 && tx<simCols && ty>=0 && ty<simRows && grid[ty][tx]===EMPTY) {
-                          newX = tx; newY = ty; placed = true;
-                        }
-                      }
-                    }
-                    if (!placed) continue;
-                  }
-                  grid[newY][newX] = grid[yy][xx];
-                  grid[yy][xx] = EMPTY;
-                  isStatic[newY][newX] = false;
-                  isStatic[yy][xx] = false;
-                }
-              }
-            }
-          }
-        }
-      }
-      bombs.splice(i, 1);
-    }
-  }
-}
-
-function updateSoilAndGrass(dt) {
-  for (let y = 0; y < simRows; y++) {
-    for (let x = 0; x < simCols; x++) {
-      if (grid[y][x] === SOIL) {
-        if (y === 0 || grid[y-1][x] === EMPTY) {
+function updateSoilAndGrass(dt){
+  for (let y=0; y<simRows; y++){
+    for (let x=0; x<simCols; x++){
+      if (grid[y][x] === SOIL){
+        if (y===0 || grid[y-1][x] === EMPTY){
           const key = `${x},${y}`;
           soilExposeTime[key] = (soilExposeTime[key] || 0) + dt;
-          if (soilExposeTime[key] >= 180) {
+          if (soilExposeTime[key] >= 180){
             grid[y][x] = GRASS;
-            grassCoverTime[key] = 0;
             soilExposeTime[key] = 0;
           }
         } else {
           soilExposeTime[`${x},${y}`] = 0;
         }
-      }
-      else if (grid[y][x] === GRASS) {
-        const key = `${x},${y}`;
-        if (y !== 0 && grid[y-1][x] !== EMPTY) {
-          grassCoverTime[key] = (grassCoverTime[key] || 0) + dt;
-          if (grassCoverTime[key] >= 30) {
-            grid[y][x] = SOIL;
-            soilExposeTime[key] = 0;
-            grassCoverTime[key] = 0;
-          }
-        } else {
-          grassCoverTime[key] = 0;
+      } else if (grid[y][x] === GRASS){
+        if (y!==0 && grid[y-1][x] !== EMPTY){
+          grid[y][x] = SOIL;
+          soilExposeTime[`${x},${y}`] = 0;
         }
       }
     }
   }
 }
 
-function draw() {
-  ctx.fillStyle = '#101014';
-  ctx.fillRect(0, 0, width, height);
-  for (let y = 0; y < simRows; y++) {
-    for (let x = 0; x < simCols; x++) {
-      switch(grid[y][x]) {
-        case SAND: ctx.fillStyle = '#fc0'; break;
-        case WATER: ctx.fillStyle = '#39f'; break;
-        case SOIL: ctx.fillStyle = '#764c24'; break;
-        case GRASS: ctx.fillStyle = '#3c9d30'; break;
-        case BOMB: ctx.fillStyle = '#f00'; break;
-        default: continue;
+function drawBackground(dt){
+  dayTime = (dayTime + dt) % 300;
+  const progress = dayTime / 300;
+  const sunHeight = Math.sin(progress * 2*Math.PI);
+  const daylight = Math.max(0, sunHeight);
+  const nightLight = 1 - daylight;
+
+  const grad = ctx.createLinearGradient(0,0,0,height);
+  grad.addColorStop(0, mixColor('#001030', '#5cc0ff', daylight));
+  grad.addColorStop(1, mixColor('#002', '#aeefff', daylight));
+  ctx.fillStyle = grad;
+  ctx.fillRect(0,0,width,height);
+
+  // stars
+  ctx.fillStyle = '#fff';
+  for (const s of stars){
+    ctx.globalAlpha = nightLight * s.alpha;
+    ctx.fillRect(s.x, s.y, s.size, s.size);
+  }
+  ctx.globalAlpha = 1;
+
+  // clouds
+  if (daylight > 0){
+    ctx.fillStyle = 'rgba(255,255,255,0.8)';
+    ctx.shadowColor = 'rgba(255,255,255,0.8)';
+    ctx.shadowBlur = 8;
+    for (const c of clouds){
+      c.x += c.speed * dt;
+      if (c.x > width + 60) c.x = -60;
+      ctx.beginPath();
+      ctx.ellipse(c.x, c.y, 40, 20, 0, 0, Math.PI*2);
+      ctx.fill();
+    }
+    ctx.shadowBlur = 0;
+  }
+
+  // sun or moon
+  const sunX = progress * width;
+  const baseY = height * 0.7;
+  const sunY = baseY - sunHeight * height * 0.5;
+  if (daylight > 0){
+    ctx.fillStyle = '#ffd35c';
+    ctx.shadowColor = '#ffd35c';
+    ctx.shadowBlur = 20;
+    ctx.beginPath();
+    ctx.arc(sunX, sunY, 20, 0, Math.PI*2);
+    ctx.fill();
+    ctx.shadowBlur = 0;
+  } else {
+    ctx.fillStyle = '#ccddee';
+    ctx.shadowColor = '#ccddee';
+    ctx.shadowBlur = 15;
+    ctx.beginPath();
+    ctx.arc(sunX, baseY - (-sunHeight) * height * 0.5, 15, 0, Math.PI*2);
+    ctx.fill();
+    ctx.shadowBlur = 0;
+  }
+}
+
+function drawTerrain(){
+  for (let y=0; y<simRows; y++){
+    for (let x=0; x<simCols; x++){
+      if (grid[y][x] === SOIL){
+        ctx.fillStyle = '#4e2b14';
+        ctx.shadowColor = '#4e2b14';
+        ctx.shadowBlur = 4;
+        ctx.fillRect(x*cellSize, y*cellSize, cellSize, cellSize);
+        ctx.shadowBlur = 0;
+      } else if (grid[y][x] === GRASS){
+        const gx=x*cellSize, gy=y*cellSize;
+        ctx.fillStyle = '#4e2b14';
+        ctx.fillRect(gx, gy, cellSize, cellSize);
+        ctx.fillStyle = '#2dd82d';
+        ctx.shadowColor = '#2dd82d';
+        ctx.shadowBlur = 6;
+        ctx.fillRect(gx, gy, cellSize, 2);
+        ctx.fillStyle = '#3cff3c';
+        ctx.fillRect(gx, gy, cellSize, 1);
+        ctx.shadowBlur = 0;
       }
-      ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
     }
   }
 }
 
+function draw(dt){
+  drawBackground(dt);
+  drawTerrain();
+}
+
 let last = performance.now();
-function loop(now) {
-  const dt = Math.min(0.05, (now - last) / 1000);
+function loop(now){
+  const dt = Math.min(0.05, (now - last)/1000);
   last = now;
   updateParticles();
-  updateBombs(dt);
   updateSoilAndGrass(dt);
-  draw();
+  draw(dt);
   requestAnimationFrame(loop);
 }
 requestAnimationFrame(loop);
 
-// Input handling
-function setMaterial(mat) {
-  currentMaterial = mat;
-  toolbar.querySelectorAll('button[data-mat]').forEach(b => {
-    b.classList.toggle('selected', parseInt(b.dataset.mat) === mat);
-  });
-}
-toolbar.querySelectorAll('button[data-mat]').forEach(btn => {
-  btn.addEventListener('click', () => setMaterial(parseInt(btn.dataset.mat)));
-});
-toolbar.querySelectorAll('input[name=mode]').forEach(radio => {
-  radio.addEventListener('change', () => { if (radio.checked) currentMode = radio.value; });
-});
-window.addEventListener('keydown', e => {
-  if (e.key === '1') setMaterial(WATER);
-  if (e.key === '2') setMaterial(SAND);
-  if (e.key === '3') setMaterial(SOIL);
-  if (e.key === '4') setMaterial(BOMB);
-});
+// interaction
+let pointerDown=false;
+let pointerButton=0;
+let pointerX=0, pointerY=0;
 
-setMaterial(currentMaterial);
-
-let pointerDown = false;
-let pointerX = 0, pointerY = 0;
-function updatePointer(e) {
+function updatePointer(e){
   const rect = canvas.getBoundingClientRect();
-  pointerX = Math.floor((e.clientX - rect.left) / cellSize);
-  pointerY = Math.floor((e.clientY - rect.top) / cellSize);
+  pointerX = Math.floor((e.clientX - rect.left)/cellSize);
+  pointerY = Math.floor((e.clientY - rect.top)/cellSize);
 }
 
-function spawnAtPointer() {
+function modifyAtPointer(btn){
   const gridX = pointerX, gridY = pointerY;
-  if (gridY < 0 || gridY >= simRows || gridX < 0 || gridX >= simCols) return;
-  if (currentMode === 'interact') {
-    if (grid[gridY][gridX] !== EMPTY) {
-      grid[gridY][gridX] = EMPTY;
-      isStatic[gridY][gridX] = false;
-      delete soilExposeTime[`${gridX},${gridY}`];
-      delete grassCoverTime[`${gridX},${gridY}`];
-    }
-    return;
-  }
-  if (currentMaterial === SOIL) {
-    const r = 2;
-    for (let dy = -r; dy <= r; dy++) {
-      for (let dx = -r; dx <= r; dx++) {
-        if (dx*dx + dy*dy <= r*r) {
-          const x = gridX + dx, y = gridY + dy;
-          if (y >= 0 && y < simRows && x >= 0 && x < simCols && grid[y][x] === EMPTY) {
+  if (gridY<0 || gridY>=simRows || gridX<0 || gridX>=simCols) return;
+  if (btn===0){
+    const r=2;
+    for (let dy=-r; dy<=r; dy++){
+      for (let dx=-r; dx<=r; dx++){
+        if (dx*dx+dy*dy <= r*r){
+          const x = gridX+dx, y = gridY+dy;
+          if (y>=0 && y<simRows && x>=0 && x<simCols && grid[y][x]===EMPTY){
             grid[y][x] = SOIL;
             isStatic[y][x] = false;
             soilExposeTime[`${x},${y}`] = 0;
@@ -329,24 +273,11 @@ function spawnAtPointer() {
         }
       }
     }
-  } else if (currentMaterial === WATER) {
-    const r = 1;
-    for (let dy = -r; dy <= r; dy++) {
-      for (let dx = -r; dx <= r; dx++) {
-        const x = gridX + dx, y = gridY + dy;
-        if (y >= 0 && y < simRows && x >= 0 && x < simCols && grid[y][x] === EMPTY) {
-          grid[y][x] = WATER;
-          isStatic[y][x] = false;
-        }
-      }
-    }
-  } else {
-    if (grid[gridY][gridX] === EMPTY) {
-      grid[gridY][gridX] = currentMaterial;
+  } else if (btn===2){
+    if (grid[gridY][gridX] !== EMPTY){
+      grid[gridY][gridX] = EMPTY;
       isStatic[gridY][gridX] = false;
-      if (currentMaterial === BOMB) {
-        bombs.push({x: gridX, y: gridY, fuse: 3});
-      }
+      delete soilExposeTime[`${gridX},${gridY}`];
     }
   }
 }
@@ -354,18 +285,19 @@ function spawnAtPointer() {
 let spawnInterval;
 canvas.addEventListener('pointerdown', e => {
   pointerDown = true;
+  pointerButton = e.button;
   updatePointer(e);
-  spawnAtPointer();
+  modifyAtPointer(pointerButton);
   clearInterval(spawnInterval);
-  const rate = currentMaterial === WATER && currentMode === 'place' ? 20 : 50;
-  spawnInterval = setInterval(spawnAtPointer, rate);
+  spawnInterval = setInterval(()=>modifyAtPointer(pointerButton), 50);
 });
-canvas.addEventListener('pointermove', e => {
-  if (pointerDown) updatePointer(e);
-});
+canvas.addEventListener('pointermove', e => { if (pointerDown) updatePointer(e); });
 ['pointerup','pointercancel','pointerout'].forEach(ev => canvas.addEventListener(ev, () => {
   pointerDown = false;
   clearInterval(spawnInterval);
 }));
+canvas.addEventListener('contextmenu', e => e.preventDefault());
 </script>
+</body>
 </html>
+


### PR DESCRIPTION
## Summary
- Replace sandbox with soil-only simulation featuring natural grassy terrain
- Implement day-night cycle with sun, moon, stars and moving clouds
- Add gentle glowing aesthetic to soil and grass tiles
- Start cycle during daylight so scene isn’t initially black
- Wrap HTML in head and body tags to prevent rendering conflicts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc821e4e0832b8f58ff027f456030