### PR TITLE
Add gravity sandbox with interactive menu and new objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,57 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Phaser + Vite</title>
+    <title>Gravity Sandbox</title>
+    <style>
+      body {
+        margin: 0;
+        background: #000;
+        color: #0ff;
+        font-family: monospace;
+      }
+      #menu {
+        display: flex;
+        gap: 4px;
+        padding: 4px;
+        background: rgba(0, 0, 0, 0.7);
+        align-items: center;
+      }
+      #palette {
+        display: none;
+        gap: 4px;
+      }
+      #palette.active {
+        display: flex;
+      }
+      button {
+        background: #111;
+        color: #0ff;
+        border: 2px solid #0ff;
+        padding: 4px 8px;
+        font-family: inherit;
+        cursor: pointer;
+      }
+      canvas {
+        image-rendering: pixelated;
+        filter: contrast(1.2) brightness(1.1);
+        display: block;
+      }
+      body::after {
+        content: '';
+        pointer-events: none;
+        position: fixed;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: linear-gradient(rgba(255,255,255,0.05) 50%, rgba(0,0,0,0.05) 50%);
+        background-size: 100% 2px;
+        mix-blend-mode: overlay;
+      }
+    </style>
   </head>
   <body>
+    <div id="menu">
+      <button id="modeBtn">Interact</button>
+      <div id="palette"></div>
+    </div>
     <div id="game"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/MainScene.js
+++ b/src/MainScene.js
@@ -4,7 +4,22 @@ const Materials = {
   EMPTY: 0,
   SAND: 1,
   WATER: 2,
-  LAVA: 3
+  LAVA: 3,
+  SOIL: 4,
+  LEAF: 5,
+};
+
+const Objects = {
+  BALL: 'BALL',
+  DYNAMITE: 'DYNAMITE',
+  SEED: 'SEED',
+  STONE: 'STONE',
+  ICE: 'ICE',
+  FIRE: 'FIRE',
+  GAS: 'GAS',
+  METAL: 'METAL',
+  OIL: 'OIL',
+  MAGNET: 'MAGNET',
 };
 
 export default class MainScene extends Phaser.Scene {
@@ -12,111 +27,280 @@ export default class MainScene extends Phaser.Scene {
     super('main');
 
     this.cellSize = 4;
-    this.gridWidth = 200;
-    this.gridHeight = 150;
+    this.mode = 'INTERACT';
+    this.currentSelection = { kind: 'material', value: Materials.SAND };
   }
 
   preload() {}
 
   create() {
-    this.grid = Array.from({ length: this.gridHeight }, () => Array(this.gridWidth).fill(Materials.EMPTY));
+    this.gridWidth = Math.floor(this.scale.width / this.cellSize);
+    this.gridHeight = Math.floor(this.scale.height / this.cellSize);
+    this.grid = Array.from({ length: this.gridHeight }, () =>
+      Array(this.gridWidth).fill(Materials.EMPTY)
+    );
     this.graphics = this.add.graphics();
     this.input.mouse.disableContextMenu();
 
-    this.currentMaterial = Materials.SAND;
     this.pointerDown = false;
 
     this.input.on('pointerdown', (pointer) => {
-      this.pointerDown = true;
-      this.handlePointer(pointer);
+      if (this.mode === 'PLACE') {
+        this.pointerDown = true;
+        this.handlePlace(pointer);
+      }
     });
     this.input.on('pointerup', () => {
       this.pointerDown = false;
     });
     this.input.on('pointermove', (pointer) => {
-      if (this.pointerDown) {
-        this.handlePointer(pointer);
+      if (this.mode === 'PLACE' && this.pointerDown) {
+        this.handlePlace(pointer);
       }
     });
 
-    this.keys = this.input.keyboard.addKeys({
-      sand: 'ONE',
-      water: 'TWO',
-      lava: 'THREE',
-      ball: 'FOUR',
-      dynamite: 'FIVE',
-      gopher: 'SIX'
+    this.input.on('drag', (pointer, gameObject, dragX, dragY) => {
+      if (this.mode === 'INTERACT') {
+        gameObject.x = dragX;
+        gameObject.y = dragY;
+      }
     });
 
-    this.physics.world.setBounds(0, 0, this.gridWidth * this.cellSize, this.gridHeight * this.cellSize);
+    this.physics.world.setBounds(
+      0,
+      0,
+      this.gridWidth * this.cellSize,
+      this.gridHeight * this.cellSize
+    );
     this.objects = this.add.group();
-    this.gophers = this.add.group();
+
+    const modeBtn = document.getElementById('modeBtn');
+    const palette = document.getElementById('palette');
+
+    modeBtn.addEventListener('click', () => {
+      this.mode = this.mode === 'INTERACT' ? 'PLACE' : 'INTERACT';
+      modeBtn.textContent = this.mode === 'INTERACT' ? 'Interact' : 'Place';
+      palette.classList.toggle('active', this.mode === 'PLACE');
+    });
+
+    const options = [
+      { kind: 'material', value: Materials.SAND, label: 'Sand' },
+      { kind: 'material', value: Materials.WATER, label: 'Water' },
+      { kind: 'material', value: Materials.LAVA, label: 'Lava' },
+      { kind: 'material', value: Materials.SOIL, label: 'Soil' },
+      { kind: 'object', value: Objects.BALL, label: 'Ball' },
+      { kind: 'object', value: Objects.DYNAMITE, label: 'Dynamite' },
+      { kind: 'object', value: Objects.SEED, label: 'Seed' },
+      { kind: 'object', value: Objects.STONE, label: 'Stone' },
+      { kind: 'object', value: Objects.ICE, label: 'Ice' },
+      { kind: 'object', value: Objects.FIRE, label: 'Fire' },
+      { kind: 'object', value: Objects.GAS, label: 'Gas' },
+      { kind: 'object', value: Objects.METAL, label: 'Metal' },
+      { kind: 'object', value: Objects.OIL, label: 'Oil' },
+      { kind: 'object', value: Objects.MAGNET, label: 'Magnet' },
+    ];
+
+    options.forEach((opt) => {
+      const btn = document.createElement('button');
+      btn.textContent = opt.label;
+      btn.addEventListener('click', () => {
+        this.currentSelection = { kind: opt.kind, value: opt.value };
+      });
+      palette.appendChild(btn);
+    });
   }
 
-  handlePointer(pointer) {
+  handlePlace(pointer) {
     const x = Math.floor(pointer.x / this.cellSize);
     const y = Math.floor(pointer.y / this.cellSize);
     if (x < 0 || x >= this.gridWidth || y < 0 || y >= this.gridHeight) return;
 
-    switch (this.currentMaterial) {
-      case Materials.SAND:
-      case Materials.WATER:
-      case Materials.LAVA:
-        for (let dy = -1; dy <= 1; dy++) {
-          for (let dx = -1; dx <= 1; dx++) {
-            const nx = x + dx;
-            const ny = y + dy;
-            if (nx >= 0 && nx < this.gridWidth && ny >= 0 && ny < this.gridHeight) {
-              this.grid[ny][nx] = this.currentMaterial;
-            }
+    if (this.currentSelection.kind === 'material') {
+      const mat = this.currentSelection.value;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && nx < this.gridWidth && ny >= 0 && ny < this.gridHeight) {
+            this.grid[ny][nx] = mat;
           }
         }
-        break;
-      case 'BALL': {
-        const ball = this.add.circle(x * this.cellSize + this.cellSize / 2, y * this.cellSize + this.cellSize / 2, this.cellSize / 2, 0xffffff);
-        this.physics.add.existing(ball);
-        this.objects.add(ball);
-        break;
       }
-      case 'DYNAMITE': {
-        const dyn = this.add.rectangle(x * this.cellSize + this.cellSize / 2, y * this.cellSize + this.cellSize / 2, this.cellSize, this.cellSize * 2, 0xff0000);
-        this.physics.add.existing(dyn);
-        this.objects.add(dyn);
-        this.time.delayedCall(2000, () => {
-          const gx = Math.floor(dyn.x / this.cellSize);
-          const gy = Math.floor(dyn.y / this.cellSize);
-          const radius = 6;
-          for (let oy = -radius; oy <= radius; oy++) {
-            for (let ox = -radius; ox <= radius; ox++) {
-              const dx = gx + ox;
-              const dy2 = gy + oy;
-              if (dx >= 0 && dx < this.gridWidth && dy2 >= 0 && dy2 < this.gridHeight) {
-                this.grid[dy2][dx] = Materials.EMPTY;
+    } else {
+      const objType = this.currentSelection.value;
+      const px = x * this.cellSize + this.cellSize / 2;
+      const py = y * this.cellSize + this.cellSize / 2;
+      switch (objType) {
+        case Objects.BALL: {
+          const ball = this.add.circle(px, py, this.cellSize / 2, 0xffffff);
+          this.physics.add.existing(ball);
+          ball.customType = Objects.BALL;
+          ball.setInteractive();
+          this.input.setDraggable(ball);
+          this.objects.add(ball);
+          break;
+        }
+        case Objects.DYNAMITE: {
+          const dyn = this.add.rectangle(
+            px,
+            py,
+            this.cellSize,
+            this.cellSize * 2,
+            0xff0000
+          );
+          this.physics.add.existing(dyn);
+          dyn.customType = Objects.DYNAMITE;
+          dyn.setInteractive();
+          this.input.setDraggable(dyn);
+          this.objects.add(dyn);
+          this.time.delayedCall(2000, () => {
+            const gx = Math.floor(dyn.x / this.cellSize);
+            const gy = Math.floor(dyn.y / this.cellSize);
+            const radius = 6;
+            for (let oy = -radius; oy <= radius; oy++) {
+              for (let ox = -radius; ox <= radius; ox++) {
+                const dx = gx + ox;
+                const dy2 = gy + oy;
+                if (
+                  dx >= 0 &&
+                  dx < this.gridWidth &&
+                  dy2 >= 0 &&
+                  dy2 < this.gridHeight
+                ) {
+                  this.grid[dy2][dx] = Materials.EMPTY;
+                }
               }
             }
-          }
-          dyn.destroy();
-        });
-        break;
-      }
-      case 'GOPHER': {
-        const gopher = this.add.rectangle(x * this.cellSize + this.cellSize / 2, y * this.cellSize + this.cellSize / 2, this.cellSize, this.cellSize * 2, 0x996633);
-        this.physics.add.existing(gopher);
-        gopher.body.setVelocityY(40);
-        this.gophers.add(gopher);
-        break;
+            dyn.destroy();
+          });
+          break;
+        }
+        case Objects.SEED: {
+          const seed = this.add.circle(px, py, this.cellSize / 2, 0x00ff00);
+          this.physics.add.existing(seed);
+          seed.customType = Objects.SEED;
+          seed.setInteractive();
+          this.input.setDraggable(seed);
+          this.objects.add(seed);
+          this.time.delayedCall(3000, () => {
+            const gx = Math.floor(seed.x / this.cellSize);
+            const gy = Math.floor(seed.y / this.cellSize);
+            for (let i = 0; i < 5; i++) {
+              const ny = gy - i;
+              if (ny >= 0) this.grid[ny][gx] = Materials.SOIL;
+            }
+            for (let oy = -2; oy <= 2; oy++) {
+              for (let ox = -2; ox <= 2; ox++) {
+                const nx = gx + ox;
+                const ny = gy - 5 + oy;
+                if (
+                  nx >= 0 &&
+                  nx < this.gridWidth &&
+                  ny >= 0 &&
+                  ny < this.gridHeight &&
+                  Math.abs(ox) + Math.abs(oy) < 3
+                ) {
+                  this.grid[ny][nx] = Materials.LEAF;
+                }
+              }
+            }
+            seed.destroy();
+          });
+          break;
+        }
+        case Objects.STONE: {
+          const stone = this.add.rectangle(px, py, this.cellSize, this.cellSize, 0x888888);
+          this.physics.add.existing(stone);
+          stone.body.setImmovable(true);
+          stone.customType = Objects.STONE;
+          stone.setInteractive();
+          this.input.setDraggable(stone);
+          this.objects.add(stone);
+          break;
+        }
+        case Objects.ICE: {
+          const ice = this.add.rectangle(px, py, this.cellSize, this.cellSize, 0x99ddee);
+          this.physics.add.existing(ice);
+          ice.customType = Objects.ICE;
+          ice.setInteractive();
+          this.input.setDraggable(ice);
+          this.objects.add(ice);
+          this.time.delayedCall(5000, () => {
+            const gx = Math.floor(ice.x / this.cellSize);
+            const gy = Math.floor(ice.y / this.cellSize);
+            ice.destroy();
+            for (let dy = -1; dy <= 1; dy++) {
+              for (let dx = -1; dx <= 1; dx++) {
+                const nx = gx + dx;
+                const ny = gy + dy;
+                if (
+                  nx >= 0 &&
+                  nx < this.gridWidth &&
+                  ny >= 0 &&
+                  ny < this.gridHeight
+                ) {
+                  this.grid[ny][nx] = Materials.WATER;
+                }
+              }
+            }
+          });
+          break;
+        }
+        case Objects.FIRE: {
+          const fire = this.add.rectangle(px, py, this.cellSize, this.cellSize, 0xffdd00);
+          this.physics.add.existing(fire);
+          fire.customType = Objects.FIRE;
+          fire.setInteractive();
+          this.input.setDraggable(fire);
+          this.objects.add(fire);
+          break;
+        }
+        case Objects.GAS: {
+          const gas = this.add.circle(px, py, this.cellSize / 2, 0xcccccc);
+          this.physics.add.existing(gas);
+          gas.body.setVelocityY(-50);
+          gas.body.setAllowGravity(false);
+          gas.customType = Objects.GAS;
+          gas.setInteractive();
+          this.input.setDraggable(gas);
+          this.objects.add(gas);
+          break;
+        }
+        case Objects.METAL: {
+          const metal = this.add.rectangle(px, py, this.cellSize, this.cellSize, 0xaaaaaa);
+          this.physics.add.existing(metal);
+          metal.body.setGravityY(600);
+          metal.customType = Objects.METAL;
+          metal.setInteractive();
+          this.input.setDraggable(metal);
+          this.objects.add(metal);
+          break;
+        }
+        case Objects.OIL: {
+          const oil = this.add.circle(px, py, this.cellSize / 2, 0x222222);
+          this.physics.add.existing(oil);
+          oil.body.setBounce(0.8);
+          oil.customType = Objects.OIL;
+          oil.setInteractive();
+          this.input.setDraggable(oil);
+          this.objects.add(oil);
+          break;
+        }
+        case Objects.MAGNET: {
+          const magnet = this.add.rectangle(px, py, this.cellSize, this.cellSize, 0xffff00);
+          this.physics.add.existing(magnet);
+          magnet.body.setImmovable(true);
+          magnet.customType = Objects.MAGNET;
+          magnet.setInteractive();
+          this.input.setDraggable(magnet);
+          this.objects.add(magnet);
+          break;
+        }
       }
     }
   }
 
   update() {
-    if (Phaser.Input.Keyboard.JustDown(this.keys.sand)) this.currentMaterial = Materials.SAND;
-    if (Phaser.Input.Keyboard.JustDown(this.keys.water)) this.currentMaterial = Materials.WATER;
-    if (Phaser.Input.Keyboard.JustDown(this.keys.lava)) this.currentMaterial = Materials.LAVA;
-    if (Phaser.Input.Keyboard.JustDown(this.keys.ball)) this.currentMaterial = 'BALL';
-    if (Phaser.Input.Keyboard.JustDown(this.keys.dynamite)) this.currentMaterial = 'DYNAMITE';
-    if (Phaser.Input.Keyboard.JustDown(this.keys.gopher)) this.currentMaterial = 'GOPHER';
-
     for (let y = this.gridHeight - 2; y >= 0; y--) {
       for (let x = 0; x < this.gridWidth; x++) {
         const cell = this.grid[y][x];
@@ -146,6 +330,39 @@ export default class MainScene extends Phaser.Scene {
       }
     }
 
+    this.objects.getChildren().forEach((obj) => {
+      if (obj.customType === Objects.FIRE) {
+        const gx = Math.floor(obj.x / this.cellSize);
+        const gy = Math.floor(obj.y / this.cellSize);
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            const nx = gx + dx;
+            const ny = gy + dy;
+            if (
+              nx >= 0 &&
+              nx < this.gridWidth &&
+              ny >= 0 &&
+              ny < this.gridHeight
+            ) {
+              this.grid[ny][nx] = Materials.LAVA;
+            }
+          }
+        }
+      } else if (obj.customType === Objects.MAGNET) {
+        this.objects.getChildren().forEach((other) => {
+          if (other.customType === Objects.METAL) {
+            const dx = obj.x - other.x;
+            const dy = obj.y - other.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist > 5 && dist < 100) {
+              other.body.velocity.x += (dx / dist);
+              other.body.velocity.y += (dy / dist);
+            }
+          }
+        });
+      }
+    });
+
     this.graphics.clear();
     for (let y = 0; y < this.gridHeight; y++) {
       for (let x = 0; x < this.gridWidth; x++) {
@@ -155,24 +372,17 @@ export default class MainScene extends Phaser.Scene {
           if (cell === Materials.SAND) color = 0xc2b280;
           if (cell === Materials.WATER) color = 0x3399ff;
           if (cell === Materials.LAVA) color = 0xff4500;
+          if (cell === Materials.SOIL) color = 0x654321;
+          if (cell === Materials.LEAF) color = 0x00ff00;
           this.graphics.fillStyle(color, 1);
-          this.graphics.fillRect(x * this.cellSize, y * this.cellSize, this.cellSize, this.cellSize);
+          this.graphics.fillRect(
+            x * this.cellSize,
+            y * this.cellSize,
+            this.cellSize,
+            this.cellSize
+          );
         }
       }
     }
-
-    this.gophers.children.each((gopher) => {
-      const gx = Math.floor(gopher.x / this.cellSize);
-      const gy = Math.floor((gopher.y + gopher.height / 2) / this.cellSize);
-      for (let dy = 0; dy < 2; dy++) {
-        const ny = gy + dy;
-        if (ny >= 0 && ny < this.gridHeight && gx >= 0 && gx < this.gridWidth) {
-          this.grid[ny][gx] = Materials.EMPTY;
-        }
-      }
-      if (gopher.y > this.gridHeight * this.cellSize) {
-        gopher.destroy();
-      }
-    });
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,9 +3,10 @@ import MainScene from './MainScene.js';
 
 const config = {
   type: Phaser.AUTO,
-  width: 800,
-  height: 600,
+  width: 375,
+  height: 812,
   backgroundColor: '#000000',
+  parent: 'game',
   physics: {
     default: 'arcade',
     arcade: {


### PR DESCRIPTION
## Summary
- Resize game to iPhone dimensions and add CRT-styled menu
- Introduce placing/interact modes with selectable materials and 10 objects
- Add basic behaviours like dynamite explosions, seed-grown trees, and fire/magnet effects

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1301a9808832bbd41ea6eec21910b