### PR TITLE
Add interactive menu for object and material selection

### DIFF
--- a/game.js
+++ b/game.js
@@ -3,6 +3,7 @@ class SandboxScene extends Phaser.Scene {
     super('sandbox');
     this.blocks = [];
     this.currentTool = 'block';
+    this.currentMaterial = 'stone';
   }
 
   preload() {
@@ -21,12 +22,32 @@ class SandboxScene extends Phaser.Scene {
     // ground
     this.matter.add.rectangle(w / 2, h - 25, w, 50, { isStatic: true, friction: 1 });
 
-    // input tool selection
-    const keys = this.input.keyboard.addKeys('ONE,TWO,THREE');
-    keys.ONE.on('down', () => (this.currentTool = 'block'));
-    keys.TWO.on('down', () => (this.currentTool = 'smallBomb'));
-    keys.THREE.on('down', () => (this.currentTool = 'bigBomb'));
+    // menu buttons
+    const toolbar = document.getElementById('toolbar');
+    toolbar.querySelectorAll('button').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        this.currentTool = btn.dataset.tool;
+        toolbar
+          .querySelectorAll('button')
+          .forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+      });
+    });
 
+    // material selection
+    document
+      .getElementById('materialSelect')
+      .addEventListener('change', (e) => {
+        this.currentMaterial = e.target.value;
+      });
+
+    // keyboard input fallback
+    const keys = this.input.keyboard.addKeys('ONE,TWO,THREE');
+    keys.ONE.on('down', () => toolbar.querySelector('button[data-tool="block"]').click());
+    keys.TWO.on('down', () => toolbar.querySelector('button[data-tool="smallBomb"]').click());
+    keys.THREE.on('down', () => toolbar.querySelector('button[data-tool="bigBomb"]').click());
+
+    // placing objects
     this.input.on('pointerdown', (pointer) => {
       switch (this.currentTool) {
         case 'block':
@@ -40,14 +61,17 @@ class SandboxScene extends Phaser.Scene {
           break;
       }
     });
-
-    this.add.text(10, 10, '1: Block  2: Small Bomb  3: Large Bomb', { font: '16px monospace', fill: '#fff' });
   }
 
   placeBlock(x, y) {
     const size = 40;
-    const rect = this.add.rectangle(x, y, size, size, 0x7f7fff);
-    this.matter.add.gameObject(rect);
+    let color = 0x7f7fff;
+    if (this.currentMaterial === 'wood') {
+      color = 0xdeb887;
+    }
+    const rect = this.add.rectangle(x, y, size, size, color);
+    const opts = this.currentMaterial === 'wood' ? { density: 0.0005 } : { density: 0.001 };
+    this.matter.add.gameObject(rect, opts);
     rect.setFriction(0.9);
     rect.setBounce(0.1);
     rect.health = 100;

--- a/index.html
+++ b/index.html
@@ -5,13 +5,60 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>Sandbox Builder</title>
 <style>
-  html, body { margin:0; height:100%; background:#0b0b0b; touch-action:none; }
-  canvas { display:block; width:100vw; height:100vh; }
+  html, body {
+    margin: 0;
+    height: 100%;
+    background: #0b0b0b;
+    touch-action: none;
+  }
+
+  canvas {
+    display: block;
+    width: 100vw;
+    height: 100vh;
+  }
+
+  #ui {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    color: #fff;
+    font-family: monospace;
+    font-size: 16px;
+  }
+
+  #ui button {
+    margin-right: 8px;
+    padding: 8px 12px;
+    font-size: 16px;
+    cursor: pointer;
+  }
+
+  #ui button.active {
+    background: #3388ff;
+    color: #fff;
+  }
+
+  #instructions {
+    margin-top: 10px;
+  }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
-<script src="game.js"></script>
 </head>
 <body>
 <div id="game"></div>
+<div id="ui">
+  <div id="toolbar">
+    <button data-tool="block" class="active">Block</button>
+    <button data-tool="smallBomb">Small Bomb</button>
+    <button data-tool="bigBomb">Large Bomb</button>
+    <select id="materialSelect">
+      <option value="stone">Stone</option>
+      <option value="wood">Wood</option>
+    </select>
+  </div>
+  <div id="instructions">Select a tool and material, then tap/click on the world to place it.</div>
+</div>
+<script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add overlay UI with buttons for blocks and bombs plus material dropdown
- Handle button clicks, keyboard fallback, and material colors/density
- Provide visible instructions for using the menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b279516114832bb61f5fc777c8073a